### PR TITLE
Inject a directory into PATH if it isn't there

### DIFF
--- a/libred/config.h.in
+++ b/libred/config.h.in
@@ -19,4 +19,6 @@
 #cmakedefine HAVE_POSIX_SPAWNP
 #cmakedefine HAVE_NSGETENVIRON
 
+#cmakedefine RED_ENSURE_PATH @RED_ENSURE_PATH@
+
 #cmakedefine APPLE

--- a/libred/red.c
+++ b/libred/red.c
@@ -44,6 +44,17 @@
 #include <linux/unistd.h>
 #include <sys/time.h>
 
+#define str(s) #s
+#define xstr(s) str(s)
+
+static char const *const red_known_good_path =
+#ifdef RED_ENSURE_PATH
+  "PATH=" xstr(RED_ENSURE_PATH) ":/usr/local/sbin:/usr/local/bin:"
+  "/usr/sbin:/usr/bin:/sbin:/bin";
+#else
+  "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+#endif
+
 #if defined HAVE_POSIX_SPAWN || defined HAVE_POSIX_SPAWNP
 #include <spawn.h>
 #endif
@@ -97,6 +108,9 @@ static int const US = 0x1f;
 
 static void log_exit(int rc);
 static long long get_timestamp();
+
+static void red_ensure_path(char const **const env);
+static void red_log_error(char const *category, char const *info);
 
 
 static red_env_t env_names =
@@ -362,6 +376,8 @@ static int call_execve(const char *path, char *const argv[],
     DLSYM(func, fp, "execve");
 
     char const **const menvp = red_update_environment(envp, &initial_env);
+    red_ensure_path(menvp);
+
     int const result = (*fp)(path, argv, (char *const *)menvp);
     red_strings_release(menvp);
     return result;
@@ -376,6 +392,8 @@ static int call_execvpe(const char *file, char *const argv[],
     DLSYM(func, fp, "execvpe");
 
     char const **const menvp = red_update_environment(envp, &initial_env);
+    red_ensure_path(menvp);
+
     int const result = (*fp)(file, argv, (char *const *)menvp);
     red_strings_release(menvp);
     return result;
@@ -431,6 +449,8 @@ static int call_posix_spawn(pid_t *restrict pid, const char *restrict path,
     DLSYM(func, fp, "posix_spawn");
 
     char const **const menvp = red_update_environment(envp, &initial_env);
+    red_ensure_path(menvp);
+
     int const result =
         (*fp)(pid, path, file_actions, attrp, argv, (char *const *restrict)menvp);
     red_strings_release(menvp);
@@ -452,12 +472,79 @@ static int call_posix_spawnp(pid_t *restrict pid, const char *restrict file,
     DLSYM(func, fp, "posix_spawnp");
 
     char const **const menvp = red_update_environment(envp, &initial_env);
+    red_ensure_path(menvp);
+
     int const result =
         (*fp)(pid, file, file_actions, attrp, argv, (char *const *restrict)menvp);
     red_strings_release(menvp);
     return result;
 }
 #endif
+
+
+static void red_log_error(char const *category, char const *info) {
+    char error_template[] = "/tmp/red-error-XXXXXX";
+    int fd = mkstemp(error_template);
+    if (fd == -1) {
+      perror("red: mkstemp");
+      exit(1);
+    }
+    dprintf(fd, "%s\n%ld\n%s\n", category, (long)getpid(), info);
+    if (close(fd) == -1) {
+      perror("red: close");
+      exit(1);
+    }
+}
+
+
+/* If ENSURE_PATH is defined, this function checks to see if the first
+ * directory in $PATH is equal to ENSURE_PATH.  If it is, this function
+ * does not change envp. Otherwise, a warning is logged to a file.
+ * Additionally,
+ * - If ENSURE_PATH is not the first path in $PATH, this function adds it.
+ * - If $PATH is empty, this function fills out $PATH with a known-good
+ *   value.
+ * - If $PATH is not in envp, this function can do nothing more than log
+ *   a warning, as envp is a const *.
+ */
+static void red_ensure_path(char const **const envp) {
+#ifdef RED_ENSURE_PATH
+  for (char const **ptr = envp; ptr != NULL; ++ptr) {
+    if (strncmp(*ptr, "PATH", 4)) {
+      continue;
+    }
+    char *colon = strchr(*ptr, ':');
+    if (colon == NULL){
+      /* PATH is empty */
+      *ptr = red_known_good_path;
+      red_log_error("empty path", "");
+      return;
+    }
+
+    char const *ensure_path = *ptr + /* PATH= */ 5;
+    if (!strncmp(ensure_path, xstr(RED_ENSURE_PATH),
+          colon - ensure_path)) {
+      /* ENSURE_PATH is first path in $PATH. This is the okay case. */
+      return;
+    }
+
+    /* Some other directory is the first path in $PATH. Add ENSURE_PATH
+     * plus a colon just after the equals sign. */
+    red_log_error("malformed path", *ptr);
+    int len = strlen(xstr(RED_ENSURE_PATH)) + strlen(ensure_path)
+              /* PATH= */ + 5
+              /* colon between first path and rest */ + 1
+              /* final null byte */ + 1;
+    char *tmp = (char *)malloc(len * sizeof(char));
+    snprintf(tmp, len, "PATH=%s:%s", xstr(RED_ENSURE_PATH), ensure_path);
+    *ptr = tmp;
+    return;
+  }
+
+  red_log_error("PATH not in env!", "");
+#endif /* ifdef RED_ENSURE_PATH */
+}
+
 
 /* this method is to write log about the process creation. */
 


### PR DESCRIPTION
Upon each invocation, red can now scan the environment for a $PATH
variable and correct it if it does not point to the right directories.

In order to configure this behaviour, red must be built with the
-DRED_FIRST_PATH flag set to the first directory that is expected to be
in $PATH.

If that directory is not the first directory in $PATH, then red shall
modify $PATH so that it is, and additionally dump a warning message. The
same thing happens if $PATH is empty.

If the environment does not contain $PATH at all, then red dumps a
diagnostic message (but does not change the environment).
